### PR TITLE
actor: Free old shells and bazooka remainings

### DIFF
--- a/src/actor.c
+++ b/src/actor.c
@@ -2550,6 +2550,8 @@ void movebullet(ACTOR *aptr)
                   // Ricochet!
                   int speed;
                   ACTOR *sptr = spawnactor(ACTOR_SMOKE, aptr->x, aptr->y, 0);
+                  if (!sptr) return;
+
                   sptr->frame = 0;
                   aptr->type = ACTOR_RICOCHET;
                   aptr->frame = 0;

--- a/src/bofh.h
+++ b/src/bofh.h
@@ -35,6 +35,8 @@
 #define VB_COMPUTERS 8
 
 #define MAX_ACTOR 2048
+#define MAX_ACTOR_RESERVED 100
+#define MAX_ACTOR_FREEING 200
 #define MAX_SMP 64
 #define MAX_BOMB 64
 #define MAX_CLOSET 64

--- a/src/makefile
+++ b/src/makefile
@@ -1,5 +1,5 @@
 CC = gcc -pthread
-CFLAGS = -Wall `sdl-config --cflags`
+CFLAGS = -g -Wall `sdl-config --cflags`
 BMECONV = ../bme/bmeconv
 LIBS = -L../bme -lbme -lm `sdl-config --libs`
 


### PR DESCRIPTION
make: Build debugging symbols

It is very hard to debug issues like segfaults without debugging
symbols and also creating a debug package is not possible this way.
So add the gcc '-g' option to build them.

actor: Fix a segfault in movebullet() ricochet handling

In the ricochet handling in movebullet() sptr is the return value
of spawnactor(). It is dereferenced directly but might be NULL.
The check for NULL is missing and this causes a segfault when
reaching MAX_ACTOR (2048) by shooting a lot of bullets with the
Uzi with unlimited ammo. So return if spawnactor() returns NULL.

actor: Free old shells and bazooka remainings

All actors are stored in an array in static memory. MAX_ACTOR is at
2048. Shells and bazooka remainings are also actors and remain for
the time of the current game. If shooting around two minutes
continuously with the Uzi with unlimited ammo, MAX_ACTOR can be
reached. This makes all weapons ineffective as no more actors can
be spawned.

So free the 200 oldest shells and bazooka remainings if the actor
array is completely filled. Iterate the actors and shift left all
subsequent actors by one if a shell or bazooka remaining is found.
This might segfault if actors are still accessed. So only do that
if further shells or bazooka remainings have to be spawned as these
aren't accessed afterwards. Reserve the last 100 actors for
temporary actors.

Fixes: GitHub issue #2