### PR TITLE
FHD screens: Double all screen sizes and adjust fade

### DIFF
--- a/bme/src/bme_gfx.c
+++ b/bme/src/bme_gfx.c
@@ -132,6 +132,11 @@ int gfx_init(unsigned xsize, unsigned ysize, unsigned framerate, unsigned flags)
     gfx_windowysize = gfx_virtualysize;
     if (gfx_scanlinemode)
     {
+        gfx_windowxsize <<= 2;
+        gfx_windowysize <<= 2;
+    }
+    else
+    {
         gfx_windowxsize <<= 1;
         gfx_windowysize <<= 1;
     }
@@ -466,31 +471,6 @@ void gfx_copyscreen8(Uint8  *destaddress, Uint8  *srcaddress, unsigned pitch)
         default:
         for (c = 0; c < gfx_virtualysize; c++)
         {
-            memcpy(destaddress, srcaddress, gfx_virtualxsize);
-            destaddress += pitch;
-            srcaddress += gfx_virtualxsize;
-        }
-        break;
-
-        case GFX_SCANLINES:
-        for (c = 0; c < gfx_virtualysize; c++)
-        {
-            d = gfx_virtualxsize;
-            while (d--)
-            {
-                *destaddress = *srcaddress;
-                destaddress++;
-                *destaddress = *srcaddress;
-                destaddress++;
-                srcaddress++;
-            }
-            destaddress += pitch*2 - (gfx_virtualxsize << 1);
-        }
-        break;
-
-        case GFX_DOUBLESIZE:
-        for (c = 0; c < gfx_virtualysize; c++)
-        {
             d = gfx_virtualxsize;
             while (d--)
             {
@@ -512,6 +492,61 @@ void gfx_copyscreen8(Uint8  *destaddress, Uint8  *srcaddress, unsigned pitch)
                 srcaddress++;
             }
             destaddress += pitch - (gfx_virtualxsize << 1);
+        }
+        break;
+
+        case GFX_SCANLINES:
+        for (c = 0; c < gfx_virtualysize; c++)
+        {
+            d = gfx_virtualxsize;
+            while (d--)
+            {
+                *destaddress = *srcaddress;
+                destaddress++;
+                *destaddress = *srcaddress;
+                destaddress++;
+                *destaddress = *srcaddress;
+                destaddress++;
+                *destaddress = *srcaddress;
+                destaddress++;
+                srcaddress++;
+            }
+            destaddress += pitch*4 - (gfx_virtualxsize << 2);
+        }
+        break;
+
+        case GFX_DOUBLESIZE:
+        for (c = 0; c < gfx_virtualysize; c++)
+        {
+            d = gfx_virtualxsize;
+            while (d--)
+            {
+                *destaddress = *srcaddress;
+                destaddress++;
+                *destaddress = *srcaddress;
+                destaddress++;
+                *destaddress = *srcaddress;
+                destaddress++;
+                *destaddress = *srcaddress;
+                destaddress++;
+                srcaddress++;
+            }
+            destaddress += pitch*2 - (gfx_virtualxsize << 2);
+            srcaddress -= gfx_virtualxsize;
+            d = gfx_virtualxsize;
+            while (d--)
+            {
+                *destaddress = *srcaddress;
+                destaddress++;
+                *destaddress = *srcaddress;
+                destaddress++;
+                *destaddress = *srcaddress;
+                destaddress++;
+                *destaddress = *srcaddress;
+                destaddress++;
+                srcaddress++;
+            }
+            destaddress += pitch*2 - (gfx_virtualxsize << 2);
         }
         break;
     }

--- a/bme/src/bme_gfx.c
+++ b/bme/src/bme_gfx.c
@@ -248,6 +248,12 @@ void gfx_calcpalette(int fade, int radd, int gadd, int badd)
     if (gadd < 0) gadd = 0;
     if (badd < 0) badd = 0;
 
+    if (gfx_scanlinemode)
+    {
+        /* increasing screen size lowers brightness */
+        fade += 20;
+    }
+
     for (c = 1; c < 255; c++)
     {
         cl = *sptr;
@@ -550,6 +556,9 @@ void gfx_copyscreen8(Uint8  *destaddress, Uint8  *srcaddress, unsigned pitch)
         }
         break;
     }
+    /* increasing screen size lowers brightness */
+    gfx_calcpalette(64, 0, 0, 0);
+    gfx_setpalette();
 }
 
 void gfx_plot(int x, int y, int color)


### PR DESCRIPTION
bme: Double all screen sizes

The original screen size is definitely too small for all modern
computers. For the standard FHD displays even quad size is required.
The display zoom is implemented in a pretty static way so adding the
quad size in addition to the double size is too cumbersome.
So double all screen sizes instead.

bme: Increase the fade for quad size window

When switching from normal size to double size, which are now
double and quad size, then there is not enough brightness any more.
So do a color palette correction when switching between the modes.
As a result of experimentation, a fade increase by 20 provides the
best result for the quad size window.